### PR TITLE
feat: add AWS CodeArtifact support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -90,6 +90,27 @@ inputs:
     description: "Registry password or token"
     required: false
 
+  # AWS CodeArtifact inputs (package manager authentication)
+  aws_codeartifact_domain:
+    description: "AWS CodeArtifact domain name"
+    required: false
+  aws_codeartifact_repository:
+    description: "AWS CodeArtifact repository name"
+    required: false
+  aws_codeartifact_tool:
+    description: "Tool to configure for CodeArtifact (npm, pip, twine, dotnet, nuget, swift)"
+    required: false
+  aws_codeartifact_region:
+    description: "Region for CodeArtifact (defaults to location/aws_region if not specified)"
+    required: false
+  aws_codeartifact_domain_owner:
+    description: "AWS account ID that owns the CodeArtifact domain (defaults to authenticated account)"
+    required: false
+  aws_codeartifact_duration:
+    description: "Duration of the CodeArtifact token in seconds"
+    required: false
+    default: "43200"
+
   # GHCR / Docker Hub / Quay (aliases for convenience - prefer registry_* inputs)
   github_token:
     description: "GitHub token for GHCR (defaults to GITHUB_TOKEN)"
@@ -302,6 +323,12 @@ runs:
         eks_cluster_name: ${{ inputs.cluster }}
         enable_ecr_login: ${{ inputs.login_to_container_registry }}
         ecr_repositories: ${{ steps.config.outputs.repositories }}
+        codeartifact_domain: ${{ inputs.aws_codeartifact_domain }}
+        codeartifact_repository: ${{ inputs.aws_codeartifact_repository }}
+        codeartifact_tool: ${{ inputs.aws_codeartifact_tool }}
+        codeartifact_region: ${{ inputs.aws_codeartifact_region }}
+        codeartifact_domain_owner: ${{ inputs.aws_codeartifact_domain_owner }}
+        codeartifact_duration: ${{ inputs.aws_codeartifact_duration }}
 
     # 5) GCP (always via KoalaOps/login-gcp-gke)
     - name: GCP login


### PR DESCRIPTION
## Summary
- Add AWS CodeArtifact authentication support for package managers (npm, pip, twine, dotnet, nuget, swift)
- Passthrough to login-aws action for AWS provider
- Automatic region and domain owner inference from existing inputs

## Changes
- Added 6 new AWS CodeArtifact inputs (prefixed with `aws_codeartifact_*`)
- Pass all CodeArtifact inputs through to login-aws action
- Added CodeArtifact example in README
- Updated highlights and permissions documentation