### PR TITLE
feat: add support for CodeArtifact token mode for Docker builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,9 +229,9 @@ Optional: `aws_session_duration` (default `3600`)
 `aws_codeartifact_domain` - Domain name
 `aws_codeartifact_repository` - Repository name
 `aws_codeartifact_tool` - Tool to configure (npm, pip, twine, dotnet, nuget, swift, maven, gradle)
-Optional: `aws_codeartifact_region` (defaults to `location`), `aws_codeartifact_domain_owner` (defaults to authenticated account), `aws_codeartifact_duration` (default `43200` = 12 hours)
+Optional: `aws_codeartifact_region` (defaults to `location`), `aws_codeartifact_domain_owner` (defaults to authenticated account), `aws_codeartifact_duration` (default `43200` = 12 hours), `aws_codeartifact_output_token` (default `false` - set to `true` for Docker builds)
 
-**Note:** For Maven/Gradle, this action exports `CODEARTIFACT_AUTH_TOKEN` and `CODEARTIFACT_REPO_URL` environment variables. See the login-aws action README for configuration examples.
+**Note:** For Maven/Gradle, this action always exports `CODEARTIFACT_AUTH_TOKEN` and `CODEARTIFACT_REPO_URL` environment variables. For other tools (npm, pip, etc.), set `aws_codeartifact_output_token: 'true'` to get token-based auth (useful for Docker builds). See the login-aws action README for configuration examples.
 
 **GCP auth**  
 `gcp_workload_identity_provider`, `gcp_service_account`, or `gcp_credentials_json`

--- a/action.yml
+++ b/action.yml
@@ -110,6 +110,10 @@ inputs:
     description: "Duration of the CodeArtifact token in seconds"
     required: false
     default: "43200"
+  aws_codeartifact_output_token:
+    description: "Output the CodeArtifact token instead of using aws codeartifact login (useful for Docker builds)"
+    required: false
+    default: "false"
 
   # GHCR / Docker Hub / Quay (aliases for convenience - prefer registry_* inputs)
   github_token:
@@ -329,6 +333,7 @@ runs:
         codeartifact_region: ${{ inputs.aws_codeartifact_region }}
         codeartifact_domain_owner: ${{ inputs.aws_codeartifact_domain_owner }}
         codeartifact_duration: ${{ inputs.aws_codeartifact_duration }}
+        codeartifact_output_token: ${{ inputs.aws_codeartifact_output_token }}
 
     # 5) GCP (always via KoalaOps/login-gcp-gke)
     - name: GCP login


### PR DESCRIPTION
## Summary
Adds passthrough support for CodeArtifact token-based authentication, enabling Docker builds that need to install packages from CodeArtifact.

## Changes
- **New input**: `aws_codeartifact_output_token` to enable token mode for any tool
- **Passthrough**: Forwards parameter to underlying `login-aws` action
- **Documentation**: Updated README to explain when to use token mode

## Use Case
When building Docker images that need to install packages from CodeArtifact, local config files (like `~/.npmrc`) aren't available inside the build context. Setting `aws_codeartifact_output_token: 'true'` provides the token as environment variables (`CODEARTIFACT_AUTH_TOKEN` and `CODEARTIFACT_REPO_URL`) that can be passed as build arguments.

## Example
```yaml
- uses: KoalaOps/cloud-login@v1
  with:
    provider: aws
    location: us-east-1
    aws_role_to_assume: ${{ vars.AWS_BUILD_ROLE }}
    aws_codeartifact_tool: npm
    aws_codeartifact_output_token: 'true'
    login_to_container_registry: true

- run: |
    docker build \
      --build-arg CODEARTIFACT_AUTH_TOKEN=${{ env.CODEARTIFACT_AUTH_TOKEN }} \
      --build-arg CODEARTIFACT_REPO_URL=${{ env.CODEARTIFACT_REPO_URL }} \
      .
```

## Dependencies
Requires KoalaOps/login-aws#5 to be merged first.