### PR TITLE
feat: add CodeArtifact namespace support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ permissions:
     aws_codeartifact_domain: my-artifacts
     aws_codeartifact_repository: npm-store
     aws_codeartifact_tool: npm
+    aws_codeartifact_namespace: my-org  # Optional: specify namespace
 
 - name: Install dependencies
   run: npm install
@@ -112,6 +113,7 @@ permissions:
     aws_codeartifact_domain: my-artifacts
     aws_codeartifact_repository: maven-repo
     aws_codeartifact_tool: maven
+    aws_codeartifact_namespace: com.mycompany  # Optional: specify namespace
 
 - name: Build with Maven
   run: mvn clean install
@@ -229,7 +231,7 @@ Optional: `aws_session_duration` (default `3600`)
 `aws_codeartifact_domain` - Domain name
 `aws_codeartifact_repository` - Repository name
 `aws_codeartifact_tool` - Tool to configure (npm, pip, twine, dotnet, nuget, swift, maven, gradle)
-Optional: `aws_codeartifact_region` (defaults to `location`), `aws_codeartifact_domain_owner` (defaults to authenticated account), `aws_codeartifact_duration` (default `43200` = 12 hours), `aws_codeartifact_output_token` (default `false` - set to `true` for Docker builds)
+Optional: `aws_codeartifact_region` (defaults to `location`), `aws_codeartifact_domain_owner` (defaults to authenticated account), `aws_codeartifact_duration` (default `43200` = 12 hours), `aws_codeartifact_namespace` (namespace for the repository), `aws_codeartifact_output_token` (default `false` - set to `true` for Docker builds)
 
 **Note:** For Maven/Gradle, this action always exports `CODEARTIFACT_AUTH_TOKEN` and `CODEARTIFACT_REPO_URL` environment variables. For other tools (npm, pip, etc.), set `aws_codeartifact_output_token: 'true'` to get token-based auth (useful for Docker builds). See the login-aws action README for configuration examples.
 

--- a/action.yml
+++ b/action.yml
@@ -110,6 +110,9 @@ inputs:
     description: "Duration of the CodeArtifact token in seconds"
     required: false
     default: "43200"
+  aws_codeartifact_namespace:
+    description: "CodeArtifact namespace for the repository"
+    required: false
   aws_codeartifact_output_token:
     description: "Output the CodeArtifact token instead of using aws codeartifact login (useful for Docker builds)"
     required: false
@@ -333,6 +336,7 @@ runs:
         codeartifact_region: ${{ inputs.aws_codeartifact_region }}
         codeartifact_domain_owner: ${{ inputs.aws_codeartifact_domain_owner }}
         codeartifact_duration: ${{ inputs.aws_codeartifact_duration }}
+        codeartifact_namespace: ${{ inputs.aws_codeartifact_namespace }}
         codeartifact_output_token: ${{ inputs.aws_codeartifact_output_token }}
 
     # 5) GCP (always via KoalaOps/login-gcp-gke)


### PR DESCRIPTION
## Summary
This PR adds support for the `--namespace` parameter in AWS CodeArtifact authentication for the cloud-login action, allowing users to specify repository namespaces for different package managers.

## Changes Made
- ✅ Added `aws_codeartifact_namespace` input parameter (optional)
- ✅ Pass namespace parameter to underlying `KoalaOps/login-aws@v1` action
- ✅ Updated documentation with namespace examples for npm and Maven
- ✅ Maintained backward compatibility with existing workflows

## Backward Compatibility
This change is fully backward compatible - existing workflows will continue to work without any modifications.

## Testing
- [x] Verified namespace parameter is correctly passed to login-aws action
- [x] Updated documentation examples with proper namespace formats
- [x] Maintained consistency with login-aws action implementation

## Examples
```yaml
# NPM with namespace
- uses: KoalaOps/cloud-login@v1
  with:
    provider: aws
    location: us-east-1
    aws_role_to_assume: ${{ vars.AWS_BUILD_ROLE }}
    aws_codeartifact_domain: my-artifacts
    aws_codeartifact_repository: npm-store
    aws_codeartifact_tool: npm
    aws_codeartifact_namespace: my-org  # Just the scope name, no @

# Maven with namespace  
- uses: KoalaOps/cloud-login@v1
  with:
    provider: aws
    location: us-east-1
    aws_role_to_assume: ${{ vars.AWS_BUILD_ROLE }}
    aws_codeartifact_domain: my-artifacts
    aws_codeartifact_repository: maven-repo
    aws_codeartifact_tool: maven
    aws_codeartifact_namespace: com.mycompany  # Maven groupId
```

## Dependencies
This PR depends on the namespace support added to `KoalaOps/login-aws@v1` action.

## References
- [AWS CodeArtifact Login Command Documentation](https://docs.aws.amazon.com/cli/latest/reference/codeartifact/login.html)
- [AWS CodeArtifact Namespace Concepts](https://docs.aws.amazon.com/codeartifact/latest/ug/codeartifact-concepts.html)