### PR TITLE
rebrand: KoalaOps → Skyhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Koala Cloud Login
+# Skyhook Cloud Login
 
 Unified cloud authentication for **AWS**, **GCP**, **Azure (beta)**, plus registry login for **ECR**, **GAR**, **ACR**, and any **Docker Registry v2** compatible registry (**GHCR**, **Docker Hub**, **Quay**, etc.) — with optional Kubernetes context setup.
 
@@ -29,7 +29,7 @@ permissions:
   packages: write   # only if you'll push to GHCR
 
 - name: Cloud login (auto)
-  uses: KoalaOps/cloud-login@v1
+  uses: skyhook-io/cloud-login@v1
   with:
     image: 123456789.dkr.ecr.us-east-1.amazonaws.com/my-svc
     login_to_container_registry: true
@@ -53,7 +53,7 @@ permissions:
   id-token: write
   contents: read
 
-- uses: KoalaOps/cloud-login@v1
+- uses: skyhook-io/cloud-login@v1
   with:
     provider: aws
     account: "123456789012"  # AWS account ID
@@ -69,7 +69,7 @@ permissions:
 ### AWS (Access keys) + ECR login (no cluster)
 
 ```yaml
-- uses: KoalaOps/cloud-login@v1
+- uses: skyhook-io/cloud-login@v1
   with:
     provider: aws
     location: eu-central-1
@@ -86,7 +86,7 @@ permissions:
   id-token: write
   contents: read
 
-- uses: KoalaOps/cloud-login@v1
+- uses: skyhook-io/cloud-login@v1
   with:
     provider: aws
     location: us-east-1
@@ -107,7 +107,7 @@ permissions:
   id-token: write
   contents: read
 
-- uses: KoalaOps/cloud-login@v1
+- uses: skyhook-io/cloud-login@v1
   with:
     provider: aws
     location: us-east-1
@@ -121,7 +121,7 @@ permissions:
   run: mvn clean install
 ```
 
-**Note:** For Maven/Gradle, configure your `settings.xml` or `build.gradle` to use the `CODEARTIFACT_AUTH_TOKEN` and `CODEARTIFACT_REPO_URL` environment variables. See [login-aws README](https://github.com/KoalaOps/login-aws#codeartifact-for-maven) for detailed configuration examples.
+**Note:** For Maven/Gradle, configure your `settings.xml` or `build.gradle` to use the `CODEARTIFACT_AUTH_TOKEN` and `CODEARTIFACT_REPO_URL` environment variables. See [login-aws README](https://github.com/skyhook-io/login-aws#codeartifact-for-maven) for detailed configuration examples.
 
 ### GCP (GKE + GAR login)
 
@@ -130,7 +130,7 @@ permissions:
   id-token: write
   contents: read
 
-- uses: KoalaOps/cloud-login@v1
+- uses: skyhook-io/cloud-login@v1
   with:
     provider: gcp
     account: my-project
@@ -148,7 +148,7 @@ permissions:
   id-token: write
   contents: read
 
-- uses: KoalaOps/cloud-login@v1
+- uses: skyhook-io/cloud-login@v1
   with:
     provider: azure
     account: ${{ vars.AZURE_SUBSCRIPTION_ID }}   # or set azure_subscription_id
@@ -169,7 +169,7 @@ permissions:
   contents: read
   packages: write
 
-- uses: KoalaOps/cloud-login@v1
+- uses: skyhook-io/cloud-login@v1
   with:
     provider: github
     login_to_container_registry: true
@@ -179,7 +179,7 @@ permissions:
 ### Docker Hub (login only)
 
 ```yaml
-- uses: KoalaOps/cloud-login@v1
+- uses: skyhook-io/cloud-login@v1
   with:
     provider: dockerhub
     login_to_container_registry: true
@@ -190,7 +190,7 @@ permissions:
 ### Quay.io (login only)
 
 ```yaml
-- uses: KoalaOps/cloud-login@v1
+- uses: skyhook-io/cloud-login@v1
   with:
     provider: quay
     login_to_container_registry: true
@@ -202,7 +202,7 @@ permissions:
 
 ```yaml
 # Preferred: Use generic registry_* inputs for any Docker Registry v2 compatible registry
-- uses: KoalaOps/cloud-login@v1
+- uses: skyhook-io/cloud-login@v1
   with:
     login_to_container_registry: true
     registry_server: registry.example.com

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
-name: Koala Cloud Login
+name: Skyhook Cloud Login
 description: |
   Unified cloud authentication with optional Kubernetes context and registry login.
-author: "KoalaOps"
+author: "Skyhook"
 
 branding:
   icon: "tag"
@@ -156,7 +156,7 @@ runs:
     - name: Parse image
       id: parse
       if: inputs.image != ''
-      uses: KoalaOps/parse-image-registry@v1
+      uses: skyhook-io/parse-image-registry@v1
       with:
         image: ${{ inputs.image }}
 
@@ -353,10 +353,10 @@ runs:
           echo "role_arn=$ROLE_ARN" >> "$GITHUB_OUTPUT"
         fi
 
-    # 5) AWS login (always via KoalaOps/login-aws)
+    # 5) AWS login (always via skyhook-io/login-aws)
     - name: AWS login
       if: steps.config.outputs.provider == 'aws'
-      uses: KoalaOps/login-aws@v1
+      uses: skyhook-io/login-aws@v1
       with:
         aws_region: ${{ steps.config.outputs.location }}
         role_to_assume: ${{ steps.aws-role.outputs.role_arn }}
@@ -375,10 +375,10 @@ runs:
         codeartifact_namespace: ${{ inputs.aws_codeartifact_namespace }}
         codeartifact_output_token: ${{ inputs.aws_codeartifact_output_token }}
 
-    # 6) GCP (always via KoalaOps/login-gcp-gke)
+    # 6) GCP (always via skyhook-io/login-gcp-gke)
     - name: GCP login
       if: steps.config.outputs.provider == 'gcp'
-      uses: KoalaOps/login-gcp-gke@v1
+      uses: skyhook-io/login-gcp-gke@v1
       with:
         credentials_json: ${{ inputs.gcp_credentials_json }}
         workload_identity_provider: ${{ inputs.gcp_workload_identity_provider }}
@@ -389,10 +389,10 @@ runs:
         # login to GAR unless user turned it off
         skip_gar_login: ${{ inputs.login_to_container_registry != 'true' }}
 
-    # 7) Azure (beta) — unified via a KoalaOps action
+    # 7) Azure (beta) — unified via a Skyhook action
     - name: Azure login
       if: steps.config.outputs.provider == 'azure'
-      uses: KoalaOps/login-azure-aks@v1
+      uses: skyhook-io/login-azure-aks@v1
       with:
         subscription_id: ${{ steps.config.outputs.account }}
         resource_group: ${{ inputs.azure_resource_group }}


### PR DESCRIPTION
## Summary
Update all references from KoalaOps to Skyhook as part of the rebranding initiative.

## Changes
- Organization: `KoalaOps` → `skyhook-io`
- Author: `KoalaOps` → `Skyhook`
- Product name: `Koala` → `Skyhook` (where applicable)
- All usage examples updated to reference `skyhook-io/*`
- All documentation and URLs updated

## Notes
- This PR should be merged before transferring the repository to the skyhook-io organization
- After transfer, GitHub will automatically redirect old URLs to new ones